### PR TITLE
Auto-updating Spryker modules on 2023-08-07 14:42

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -331,6 +331,7 @@
         "spryker/sales-return-gui": "1.5.0",
         "spryker/sales-returns-rest-api": "^1.1.0",
         "spryker/sales-statistics": "^1.2.0",
+        "spryker/scheduler": "1.2.1",
         "spryker/scheduler-jenkins": "^1.2.1",
         "spryker/secrets-manager": "^1.0.0",
         "spryker/secrets-manager-aws": "^1.0.1",

--- a/composer.json
+++ b/composer.json
@@ -292,7 +292,7 @@
         "spryker/product-merchant-portal-gui": "3.0.0",
         "spryker/product-offer-gui": "1.3.0",
         "spryker/product-offer-merchant-portal-gui": "2.0.0",
-        "spryker/product-offer-storage": "1.2.0",
+        "spryker/product-offer-storage": "1.2.1",
         "spryker/product-option-cart-connector": "^7.1.2",
         "spryker/product-options-rest-api": "^1.2.0",
         "spryker/product-prices-rest-api": "^1.6.0",

--- a/composer.json
+++ b/composer.json
@@ -292,7 +292,7 @@
         "spryker/product-merchant-portal-gui": "3.0.0",
         "spryker/product-offer-gui": "1.3.0",
         "spryker/product-offer-merchant-portal-gui": "2.0.0",
-        "spryker/product-offer-storage": "1.2.1",
+        "spryker/product-offer-storage": "1.3.0",
         "spryker/product-option-cart-connector": "^7.1.2",
         "spryker/product-options-rest-api": "^1.2.0",
         "spryker/product-prices-rest-api": "^1.6.0",

--- a/composer.json
+++ b/composer.json
@@ -322,7 +322,7 @@
         "spryker/sales": "11.36.1",
         "spryker/sales-configurable-bundle": "1.5.1",
         "spryker/sales-invoice": "1.2.1",
-        "spryker/sales-merchant-portal-gui": "2.0.0",
+        "spryker/sales-merchant-portal-gui": "2.0.1",
         "spryker/sales-order-threshold": "1.7.2",
         "spryker/sales-order-thresholds-rest-api": "^1.0.0",
         "spryker/sales-payment": "1.3.0",

--- a/composer.json
+++ b/composer.json
@@ -202,6 +202,8 @@
         "spryker/flysystem-local-file-system": "^2.0.0",
         "spryker/form": "1.2.0",
         "spryker/gift-card": "1.8.0",
+        "spryker/glue-backend-api-application": "1.1.0",
+        "spryker/glue-storefront-api-application": "1.1.0",
         "spryker/gui-table": "2.0.0",
         "spryker/http": "1.8.0",
         "spryker/install": "1.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d676410655ec4a87bc626707d227847c",
+    "content-hash": "260b6d48bb83d564db4f53561cd3db96",
     "packages": [
         {
             "name": "async-aws/core",
@@ -48271,16 +48271,16 @@
         },
         {
             "name": "spryker/sales-merchant-portal-gui",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/sales-merchant-portal-gui.git",
-                "reference": "a5a158581c00c031f1bb9ca2b2b3e83d774483ee"
+                "reference": "265546ee7f45e458153e0488043604b6d0455cc6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/sales-merchant-portal-gui/zipball/a5a158581c00c031f1bb9ca2b2b3e83d774483ee",
-                "reference": "a5a158581c00c031f1bb9ca2b2b3e83d774483ee",
+                "url": "https://api.github.com/repos/spryker/sales-merchant-portal-gui/zipball/265546ee7f45e458153e0488043604b6d0455cc6",
+                "reference": "265546ee7f45e458153e0488043604b6d0455cc6",
                 "shasum": ""
             },
             "require": {
@@ -48330,9 +48330,9 @@
             ],
             "description": "SalesMerchantPortalGui module",
             "support": {
-                "source": "https://github.com/spryker/sales-merchant-portal-gui/tree/2.0.0"
+                "source": "https://github.com/spryker/sales-merchant-portal-gui/tree/2.0.1"
             },
-            "time": "2023-02-10T12:12:31+00:00"
+            "time": "2023-02-20T09:40:44+00:00"
         },
         {
             "name": "spryker/sales-merchant-portal-gui-extension",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "38c27505afef171739a2097a5219760f",
+    "content-hash": "73b8f2e4d3bdb725c7fecfd9b99472bd",
     "packages": [
         {
             "name": "async-aws/core",
@@ -43752,16 +43752,16 @@
         },
         {
             "name": "spryker/product-offer-storage",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/product-offer-storage.git",
-                "reference": "445d370c73766f6a405b33fb91e1ca8e8372ef40"
+                "reference": "4c2e0f458ebd444b943228411413f2879ffca40b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/product-offer-storage/zipball/445d370c73766f6a405b33fb91e1ca8e8372ef40",
-                "reference": "445d370c73766f6a405b33fb91e1ca8e8372ef40",
+                "url": "https://api.github.com/repos/spryker/product-offer-storage/zipball/4c2e0f458ebd444b943228411413f2879ffca40b",
+                "reference": "4c2e0f458ebd444b943228411413f2879ffca40b",
                 "shasum": ""
             },
             "require": {
@@ -43808,9 +43808,9 @@
             ],
             "description": "ProductOfferStorage module",
             "support": {
-                "source": "https://github.com/spryker/product-offer-storage/tree/1.2.0"
+                "source": "https://github.com/spryker/product-offer-storage/tree/1.2.1"
             },
-            "time": "2023-01-16T13:42:24+00:00"
+            "time": "2023-02-13T09:09:40+00:00"
         },
         {
             "name": "spryker/product-offer-storage-extension",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ecf2261e66d5886872a397306d6eae18",
+    "content-hash": "38c27505afef171739a2097a5219760f",
     "packages": [
         {
             "name": "async-aws/core",
@@ -49724,20 +49724,20 @@
         },
         {
             "name": "spryker/scheduler",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/scheduler.git",
-                "reference": "ba73b4b67699cc539a082a2954df88849a03ab69"
+                "reference": "d594f93a4d2f3b871c1b94d42048d2ca1f804386"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/scheduler/zipball/ba73b4b67699cc539a082a2954df88849a03ab69",
-                "reference": "ba73b4b67699cc539a082a2954df88849a03ab69",
+                "url": "https://api.github.com/repos/spryker/scheduler/zipball/d594f93a4d2f3b871c1b94d42048d2ca1f804386",
+                "reference": "d594f93a4d2f3b871c1b94d42048d2ca1f804386",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
+                "php": ">=8.0",
                 "spryker/graceful-runner": "^1.0.0",
                 "spryker/kernel": "^3.30.0",
                 "spryker/scheduler-extension": "^1.0.0",
@@ -49772,9 +49772,9 @@
             ],
             "description": "Scheduler module",
             "support": {
-                "source": "https://github.com/spryker/scheduler/tree/1.2.0"
+                "source": "https://github.com/spryker/scheduler/tree/1.2.1"
             },
-            "time": "2021-02-17T09:10:22+00:00"
+            "time": "2023-02-13T08:47:24+00:00"
         },
         {
             "name": "spryker/scheduler-extension",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a58c96442e6a7ead8a5485e781bb24cb",
+    "content-hash": "d676410655ec4a87bc626707d227847c",
     "packages": [
         {
             "name": "async-aws/core",
@@ -30743,20 +30743,20 @@
         },
         {
             "name": "spryker/glue-backend-api-application",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/glue-backend-api-application.git",
-                "reference": "9f4c627ec88033d2ef2244e812b51499b6d7df19"
+                "reference": "ab33db80c05a615ab6542deef8ca16f2b9fc33cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/glue-backend-api-application/zipball/9f4c627ec88033d2ef2244e812b51499b6d7df19",
-                "reference": "9f4c627ec88033d2ef2244e812b51499b6d7df19",
+                "url": "https://api.github.com/repos/spryker/glue-backend-api-application/zipball/ab33db80c05a615ab6542deef8ca16f2b9fc33cb",
+                "reference": "ab33db80c05a615ab6542deef8ca16f2b9fc33cb",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.4",
+                "php": ">=8.0",
                 "spryker/application": "^3.28.0",
                 "spryker/container": "^1.4.5",
                 "spryker/documentation-generator-api-extension": "^1.0.0",
@@ -30791,9 +30791,9 @@
             ],
             "description": "GlueBackendApiApplication module",
             "support": {
-                "source": "https://github.com/spryker/glue-backend-api-application/tree/1.0.0"
+                "source": "https://github.com/spryker/glue-backend-api-application/tree/1.1.0"
             },
-            "time": "2022-09-28T14:47:08+00:00"
+            "time": "2023-02-14T15:02:34+00:00"
         },
         {
             "name": "spryker/glue-json-api-convention",
@@ -30889,20 +30889,20 @@
         },
         {
             "name": "spryker/glue-storefront-api-application",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/glue-storefront-api-application.git",
-                "reference": "3789e31d3eaba5459e477f74b5a8b87064c68306"
+                "reference": "9d35c5734478ac469401803c20ce9a088987733d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/glue-storefront-api-application/zipball/3789e31d3eaba5459e477f74b5a8b87064c68306",
-                "reference": "3789e31d3eaba5459e477f74b5a8b87064c68306",
+                "url": "https://api.github.com/repos/spryker/glue-storefront-api-application/zipball/9d35c5734478ac469401803c20ce9a088987733d",
+                "reference": "9d35c5734478ac469401803c20ce9a088987733d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.4",
+                "php": ">=8.0",
                 "spryker/application": "^3.28.0",
                 "spryker/container": "^1.4.5",
                 "spryker/documentation-generator-api-extension": "^1.0.0",
@@ -30938,9 +30938,9 @@
             ],
             "description": "GlueStorefrontApiApplication module",
             "support": {
-                "source": "https://github.com/spryker/glue-storefront-api-application/tree/1.0.0"
+                "source": "https://github.com/spryker/glue-storefront-api-application/tree/1.1.0"
             },
-            "time": "2022-09-28T14:47:08+00:00"
+            "time": "2023-02-14T15:02:34+00:00"
         },
         {
             "name": "spryker/graceful-runner",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "73b8f2e4d3bdb725c7fecfd9b99472bd",
+    "content-hash": "a58c96442e6a7ead8a5485e781bb24cb",
     "packages": [
         {
             "name": "async-aws/core",
@@ -43752,16 +43752,16 @@
         },
         {
             "name": "spryker/product-offer-storage",
-            "version": "1.2.1",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/product-offer-storage.git",
-                "reference": "4c2e0f458ebd444b943228411413f2879ffca40b"
+                "reference": "d164a75a0fea657406a137a4dfe881e7d932a33a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/product-offer-storage/zipball/4c2e0f458ebd444b943228411413f2879ffca40b",
-                "reference": "4c2e0f458ebd444b943228411413f2879ffca40b",
+                "url": "https://api.github.com/repos/spryker/product-offer-storage/zipball/d164a75a0fea657406a137a4dfe881e7d932a33a",
+                "reference": "d164a75a0fea657406a137a4dfe881e7d932a33a",
                 "shasum": ""
             },
             "require": {
@@ -43808,9 +43808,9 @@
             ],
             "description": "ProductOfferStorage module",
             "support": {
-                "source": "https://github.com/spryker/product-offer-storage/tree/1.2.1"
+                "source": "https://github.com/spryker/product-offer-storage/tree/1.3.0"
             },
-            "time": "2023-02-13T09:09:40+00:00"
+            "time": "2023-02-14T07:21:59+00:00"
         },
         {
             "name": "spryker/product-offer-storage-extension",


### PR DESCRIPTION
Auto created via Upgrader tool.

#### Overview
Report ID: 749919fe-5fe7-481d-a26b-c5b5fe470bb3

​
**The process was faced with the blocker:**

There is a major release available for module spryker/catalog-extension. Please follow the link below to find all documentation needed to help you upgrade to the latest release 
https://api.release.spryker.com/release-group/4672

**Packages upgraded:**
| Package | From | To | Changes | 
|---------|------|----|--------|
 | **spryker/scheduler** | 1.2.0 | 1.2.1 | https://github.com/spryker/scheduler/compare/1.2.0...1.2.1 | 
 | **spryker/product-offer-storage** | 1.2.0 | 1.2.1 | https://github.com/spryker/product-offer-storage/compare/1.2.0...1.2.1 | 
 | **spryker/product-offer-storage** | 1.2.1 | 1.3.0 | https://github.com/spryker/product-offer-storage/compare/1.2.1...1.3.0 | 
 | **spryker/glue-backend-api-application** | 1.0.0 | 1.1.0 | https://github.com/spryker/glue-backend-api-application/compare/1.0.0...1.1.0 | 
 | **spryker/glue-storefront-api-application** | 1.0.0 | 1.1.0 | https://github.com/spryker/glue-storefront-api-application/compare/1.0.0...1.1.0 | 
 | **spryker/sales-merchant-portal-gui** | 2.0.0 | 2.0.1 | https://github.com/spryker/sales-merchant-portal-gui/compare/2.0.0...2.0.1 | 

